### PR TITLE
Remove x-ua compatible meta tag

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2,7 +2,6 @@
 <html lang="en">
   <head>
     <meta charset="utf-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
     <link rel="icon" href="<%= BASE_URL %>favicon.ico">
     <title>Earthlife</title>


### PR DESCRIPTION
Remove this X-UA compatible meta tag because it's not needed anymore. And we're not going to support IE, I think.

Read more: https://stackoverflow.com/a/6771584/20838