### PR TITLE
Put prettier single quote config in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,10 +26,7 @@
     "env": {
       "node": true
     },
-    "extends": [
-      "plugin:vue/essential",
-      "eslint:recommended"
-    ],
+    "extends": ["plugin:vue/essential", "eslint:recommended"],
     "rules": {},
     "parserOptions": {
       "parser": "babel-eslint"
@@ -40,9 +37,8 @@
       "autoprefixer": {}
     }
   },
-  "browserslist": [
-    "> 1%",
-    "last 2 versions",
-    "not ie <= 8"
-  ]
+  "browserslist": ["> 1%", "last 2 versions", "not ie <= 8"],
+  "prettier": {
+    "singleQuote": true
+  }
 }


### PR DESCRIPTION
Config for prettier is added in package.json to use single quote instead of double quote