### PR TITLE
Add removedActions list 

### DIFF
--- a/src/store.js
+++ b/src/store.js
@@ -8,7 +8,8 @@ export default new Vuex.Store({
   state: {
     categories: [],
     questions: {},
-    actionList: []
+    actionList: [],
+    removedActions: []
   },
 
   getters: {
@@ -136,6 +137,16 @@ export default new Vuex.Store({
       });
 
       console.log(state.actionList);
+    },
+
+    addToRemoveActionList(state, action) {
+      state.removedActions.push(action);
+    },
+
+    deleteFromRemoveActionList(state, action) {
+      state.removedActions = state.removedActions.filter(removedAction => {
+        return removedAction != action;
+      });
     }
   },
   actions: {

--- a/src/views/Question.vue
+++ b/src/views/Question.vue
@@ -116,12 +116,20 @@ export default {
           this.$store.state.questions[this.question.id].options[
             index
           ].selected = selected;
-        }
-      );
 
-      //store value is not updated in vue-devtools?
-      console.log(
-        this.$store.state.questions[this.question.id].options[0].selected
+          if (option.removeAction != '') {
+            if (selected) {
+              //Add to removedAction list
+              this.$store.commit('addToRemoveActionList', option.removeAction);
+            } else {
+              //Delete from removedAction list
+              this.$store.commit(
+                'deleteFromRemoveActionList',
+                option.removeAction
+              );
+            }
+          }
+        }
       );
 
       //Check if it's the last question

--- a/src/views/Question.vue
+++ b/src/views/Question.vue
@@ -126,15 +126,6 @@ export default {
 
       //Check if it's the last question
       if (this.question.lastQuestion) {
-        let categories = this.$store.state.categories;
-        let categorySlug = this.$route.params.category;
-
-        let categoryIndex = categories.findIndex(function(c) {
-          return c.slug == categorySlug;
-        });
-
-        this.$store.state.categories[categoryIndex].completed = true;
-
         this.$router.push({ name: 'result' });
       } else {
         //Go to next question


### PR DESCRIPTION
When the user answer the qns, if the answer has the "remove action" value, add it into the store.

e.g. if you choose the first option, this qns will add A39 into the `removedActions` array

![](https://puu.sh/BZTmE/ffc2b88c0c.png)


If the user comes back and change their answer, it'll delete the action from the array. 🎉 🎉 🎉 

![](https://puu.sh/BZTma/7c59545ac4.png)

