### PR TITLE
Change height to follow viewport

### DIFF
--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -54,7 +54,7 @@ export default {
   background-position: bottom center;
   background-repeat: no-repeat;
   background-size: 160%;
-  height: 700px;
+  height: calc(100vh - 120px);
 }
 
 a {


### PR DESCRIPTION
The main page background is not at the bottom because the height is fixed at 700px.

![chrome_2018-11-14_19-09-45](https://user-images.githubusercontent.com/8704966/48479365-0b4ecf80-e842-11e8-9b31-0546851ca9a2.png)

The top banner height is 45px and 75px respectively. Should we change the height to be 100vh - 120px?
