### PR TITLE
Fix button arrow size

### DIFF
--- a/src/views/Actions.vue
+++ b/src/views/Actions.vue
@@ -101,7 +101,7 @@ button {
   color: inherit;
   border: none;
   padding: 0;
-  font: inherit;
+  /* font: inherit; */
   cursor: pointer;
   outline: inherit;
 }
@@ -144,15 +144,16 @@ input[type='radio'] {
 
 .next {
   background-color: #4e4d86;
-  width: 50px;
-  height: 50px;
+  width: 52px;
+  height: 52px;
   border-radius: 100px;
   color: white;
   margin: 0 auto;
+  padding-top: 5px;
 }
 
 .next-content {
-  padding-top: 3px;
+  /* padding-top: 3px; */
 }
 
 .actions-intro-message {

--- a/src/views/Question.vue
+++ b/src/views/Question.vue
@@ -220,16 +220,14 @@ export default {
   margin: 60px auto 40px;
   cursor: pointer;
   display: block;
+  border: none;
+  padding-top: 5px;
 }
 
 .submit-button[disabled] {
   opacity: 0.5;
   background-color: #4e4d86;
   cursor: default;
-}
-
-.arrow {
-  padding-top: 5px;
 }
 
 .habit-tracker {


### PR DESCRIPTION
Somehow the arrow size is freakin small.

Before:
![chrome_2018-11-14_19-44-35](https://user-images.githubusercontent.com/8704966/48480898-cb3e1b80-e846-11e8-8ee5-316952154394.png)

After:
![chrome_2018-11-14_19-45-13](https://user-images.githubusercontent.com/8704966/48480906-ce390c00-e846-11e8-9a8c-4564a5b9cbe2.png)

And also change the button in the action page to follow the other buttons. 
Why is `font: inherit` causing the padding to change? 🤔 