### PR TITLE
Add a div element for action items without image 

### DIFF
--- a/src/views/Actions.vue
+++ b/src/views/Actions.vue
@@ -219,7 +219,6 @@ input[type='radio'] {
   margin-left: 20px;
   margin-right: 20px;
   padding: 0 5px;
-  outline-style: solid;
 }
 
 hr {

--- a/src/views/Actions.vue
+++ b/src/views/Actions.vue
@@ -215,9 +215,11 @@ input[type='radio'] {
 .current-card-message {
   margin: 0 auto;
   font-size: 17px;
-  margin-top: 10px;
-  padding-left: 20px;
-  padding-right: 20px;
+  margin-bottom: 0px;
+  margin-left: 20px;
+  margin-right: 20px;
+  padding: 0 5px;
+  outline-style: solid;
 }
 
 hr {
@@ -287,15 +289,17 @@ hr {
 }
 
 .add-space {
-  margin: 0 auto;
-  height: 200px;
-  width: 200px;
+  height: 13em;
 }
 
 @media only screen and (max-width: 700px) {
   .actions-intro-message {
     width: 90%;
     padding-top: 80px;
+  }
+
+  .add-space {
+    height: 10em;
   }
 
   .label {

--- a/src/views/Actions.vue
+++ b/src/views/Actions.vue
@@ -18,7 +18,8 @@
         <div class="current-card">
           <h1> {{ actions.item[actionCounter] ? actions.item[actionCounter].category : '' }} </h1>
           <hr/>
-          <img class="current-card-image" v-bind:src="this.actions.item[actionCounter].linkImage" />
+          <img class="current-card-image" v-if="this.actions.item[actionCounter].linkImage" v-bind:src="this.actions.item[actionCounter].linkImage" />
+          <div class="add-space" v-else></div>
           <p class="current-card-message">{{ actions.item[actionCounter].text }}</p>
         </div>
       </div>
@@ -283,6 +284,12 @@ hr {
 .option-button:hover {
   background-color: #f8f8f8;
   opacity: 0.8;
+}
+
+.add-space {
+  margin: 0 auto;
+  height: 200px;
+  width: 200px;
 }
 
 @media only screen and (max-width: 700px) {


### PR DESCRIPTION
Meant to avoid the text from 'jumping up and down' when there is no picture in action card.

<img width="324" alt="screenshot 2018-11-20 23 18 02" src="https://user-images.githubusercontent.com/25055570/48783088-8fa9c280-ed1a-11e8-854e-ad9f3f2ee223.png">
