### PR TITLE
Align steps page to design

### DIFF
--- a/src/views/Steps.vue
+++ b/src/views/Steps.vue
@@ -3,7 +3,7 @@
     <div class="steps-containers">
       <div class="step1">
         <h1>Step 1</h1>
-        <p>See how you're doing based on the 6 living habits of Earthlife</p>
+        <p>See how you're doing based on the 6 living habits of EarthLife</p>
         <router-link to="habits" class="button">Start Quiz <v-icon class='arrow' name="arrow-right"/></router-link>
       </div>
       <div class="step2">
@@ -22,47 +22,32 @@ export default {
 </script>
 
 <style scoped>
-.main {
-
-}
 .steps {
   background-color: #f4f6f8;
   text-align: left;
   background-image: url('../assets/Group 2.png');
   background-repeat: no-repeat;
   background-position: center bottom;
-  background-size: contain;
+  background-size: 250%;
   width: 100%;
   display: static;
-  height: 800px;
+  min-height: 600px;
   flex: 0;
 }
 
 .steps-containers {
-  padding: 15px 15%;
-  font-size: 20px;
+  padding: 15px 20px;
   line-height: 30px;
   font-weight: 500;
 }
 
 h1 {
-  font-size: 16px;
+  font-size: 14px;
   text-transform: uppercase;
-  margin: 24px;
   color: #637381;
   letter-spacing: 4.1px;
   font-weight: 500;
   line-height: 25px;
-}
-
-img {
-  width: 230px;
-}
-
-ol {
-  list-style: none;
-  margin: 0;
-  padding: 0;
 }
 
 span {
@@ -71,16 +56,12 @@ span {
 
 .step1 {
   margin-top: 20px;
+  padding: 20px 20px;
   background-color: #ffffff;
-  padding: 15px;
 }
 
 .step2 {
   padding: 20px 20px;
-}
-
-p {
-  padding-left: 20px;
 }
 
 .button {
@@ -91,39 +72,34 @@ p {
   color: white;
   border-radius: 50px;
   font-weight: normal;
+  font-size: 16px;
 }
 .arrow {
   position: absolute;
-  margin: -23px 0px 0px 102px;
+  margin: -23px 0px 0px 85px;
 }
 
-@media (min-width: 500px) {
+@media (min-width: 600px) {
   .steps {
     background-size: 100%;
     height: 100%;
+  }
+
+  .arrow {
+    position: absolute;
+    margin: -23px 0px 0px 85px;
+  }
+
+  .step1,
+  .step2 {
+    padding: 20px 34px;
   }
 
   .steps-containers {
     padding: 50px 25%;
     width: 100%;
     min-height: 100vh;
-  }
-
-  ol {
-    display: flex;
-    flex-wrap: wrap;
-    margin: 0;
-    padding: 0;
-  }
-
-  li {
-    padding: 0 20px;
-    width: 33%;
-    box-sizing: border-box;
-  }
-
-  li img {
-    width: 100%;
+    font-size: 20px;
   }
 }
 </style>


### PR DESCRIPTION
- Remove unused classes in steps page; 
- Edit text in step 1 from Earthlife to EarthLife;
- switch font size for mobile (from 20px to 16px) and desktop view (from 16px to 20px); 
- reduce height of image to reduce scrolling; 
- enlarge background image size in mobile view; 
- change breakpoint to avoid distortion of button; 
- change padding to align to mockup;
- reduce font-size in button.

**Current version:**
<img width="165" alt="screenshot 2018-11-24 08 47 13" src="https://user-images.githubusercontent.com/25055570/48963044-95770080-efc5-11e8-877d-0c4a535ac66b.png">

**Edited version:**
<img width="253" alt="screenshot 2018-11-24 08 37 51" src="https://user-images.githubusercontent.com/25055570/48963006-9c514380-efc4-11e8-9fa9-430cab73e388.png">
