### PR TITLE
Reduce image sizes of habit trackers to show them in one line in mobile view

### DIFF
--- a/src/views/Question.vue
+++ b/src/views/Question.vue
@@ -321,7 +321,7 @@ export default {
 }
 
 .habit-category {
-  width: 38px;
+  width: 36px;
   height: auto;
   margin-left: 10.5px;
   filter: grayscale(100%);


### PR DESCRIPTION
**Current view:**

<img width="329" alt="screenshot 2018-11-24 14 18 15" src="https://user-images.githubusercontent.com/25055570/48965201-dc7bea80-eff3-11e8-9f1b-54aa09203210.png">
