### PR TITLE
Hide scrollbar in action page

### DIFF
--- a/src/views/Actions.vue
+++ b/src/views/Actions.vue
@@ -1,5 +1,5 @@
 <template>
-<div>
+<div class="actions">
   <div class="wrapper">
     <div class="back-button">
       <v-icon name="arrow-left"/>
@@ -137,6 +137,11 @@ export default {
 </script>
 
 <style scoped>
+.actions {
+  overflow: hidden;
+  height: calc(100vh - 75px);
+}
+
 .card:nth-child(4n) {
   border: solid 20px #f2a069;
   background-color: white;


### PR DESCRIPTION
Fix a bug where scrollbar appears when action card is going out of the window.