### PR TITLE
Make background size to fit window

### DIFF
--- a/src/views/Steps.vue
+++ b/src/views/Steps.vue
@@ -28,6 +28,7 @@ export default {
   background-image: url('../assets/Group 2.png');
   background-repeat: no-repeat;
   background-position: center bottom;
+  background-size: 100%;
   flex-grow: 1;
 }
 


### PR DESCRIPTION
The background in the Steps page didn't fit the window (there are odd gaps on the left and right)

![](https://i.imgur.com/P7j3bM4.png)
