### PR TITLE
Let scrollbar show when it’s showing intro message

### DIFF
--- a/src/views/Actions.vue
+++ b/src/views/Actions.vue
@@ -1,5 +1,5 @@
 <template>
-<div class="actions">
+<div :class="{'actions' : !(this.showIntroMessage)}">
   <div class="wrapper">
     <div class="back-button">
       <v-icon name="arrow-left"/>


### PR DESCRIPTION
Because for iPhone 5 they need to scroll down


![](https://puu.sh/C8vij/000743e0b7.png)
