### PR TITLE
Fix weird card size

### DIFF
--- a/src/components/Card.vue
+++ b/src/components/Card.vue
@@ -147,7 +147,8 @@ export default {
   text-align: center;
   border-radius: 24px;
   position: absolute;
-  left: calc(50% - 140px);
+  left: 0;
+  right: 0;
 }
 
 .current-card-image {
@@ -196,7 +197,6 @@ export default {
   .card {
     max-width: 340px;
     height: 490px;
-    left: calc(50% - 170px);
   }
   .current-card-image {
     max-height: none;


### PR DESCRIPTION
If the text is too short, the card appears smaller 😱 

![chrome_2018-12-13_20-08-43](https://user-images.githubusercontent.com/8704966/49940722-54667200-ff1b-11e8-9a46-052fb16aa437.png)

![chrome_2018-12-13_20-08-56](https://user-images.githubusercontent.com/8704966/49940748-706a1380-ff1b-11e8-809a-232eeb89d3d4.png)


@cheeaun  Is there any reason why `left: 0` and `right: 0` are replaced by `left: calc(50% - 140px);`?